### PR TITLE
adding google website url on sidekick

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -12,6 +12,15 @@
 				"**.docx**"
 			],
 			"paletteRect": "top: 50px; bottom: 10px; right: 10px; left: auto; width:400px; height: calc(100vh - 60px)"
+		},
+		{
+			"id": "google",
+			"title": "Google Site",
+			"environments": [
+				"edit"
+			],
+			"url": "www.google.com",
+			"isPalette": false
 		}
 	]
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #14

Test URLs:
- Before: https://main--edge-delivery-demo--duggalrajeev.hlx.page/
- After: https://feature-aem-assets-sidekick--edge-delivery-demo--duggalrajeev.hlx.page/
